### PR TITLE
feat: update to .NET 10 with AnyCPU support and modernize build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,17 +23,30 @@ on:
     - global.json
   workflow_dispatch:
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
-  build:
+  build-test:
+    strategy:
+      matrix:
+        include:
+        - os: windows-latest
+          arch: x64
+        - os: windows-11-arm
+          arch: arm64
+
+    runs-on: ${{ matrix.os }}
 
     env:
       BUILD_CONFIG: 'Release'
       SOLUTION: 'WindowWatcher.sln'
 
-    runs-on: windows-latest
-
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
 
     - name: Get Build Version
       run: |
@@ -43,33 +56,96 @@ jobs:
         echo "BUILD_VERSION=$version" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
       shell: pwsh
 
-    - name: Setup .NET 6.0
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: 6.0.x
-
-    - name: Setup .NET 7.0
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: 7.0.x
-
     - name: Setup .NET 8.0
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v4
       with:
         dotnet-version: 8.0.x
 
-    - name: Restore dependencies
-      run: dotnet restore $SOLUTION
+    - name: Setup .NET 10.0
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: 10.0.x
 
-    - name: Setup MSBuild
-      uses: microsoft/setup-msbuild@v1.1.3
+    - name: Restore dependencies
+      run: dotnet restore $env:SOLUTION
 
     - name: Build
-      run: msbuild $env:SOLUTION /p:Configuration=$env:BUILD_CONFIG /p:Platform="Any CPU" -p:Version=$env:BUILD_VERSION
+      run: dotnet build $env:SOLUTION --configuration $env:BUILD_CONFIG --no-restore -p:Version=$env:BUILD_VERSION
 
-    # - name: Run tests
-    #   run: dotnet test /p:Configuration=$env:BUILD_CONFIG /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura --no-restore --no-build --verbosity normal
+    - name: Run tests
+      run: >
+        dotnet test
+        --configuration $env:BUILD_CONFIG
+        --no-restore
+        --no-build
+        --collect:"XPlat Code Coverage"
 
-    - name: Publish
-      if: startsWith(github.ref, 'refs/tags/v')
-      run: nuget push **\*.nupkg -Source 'https://api.nuget.org/v3/index.json' -ApiKey ${{secrets.NUGET_API_KEY}}
+    - name: Generate coverage report
+      uses: danielpalme/ReportGenerator-GitHub-Action@5
+      with:
+        reports: '**/coverage.cobertura.xml'
+        targetdir: 'coverage-report'
+        reporttypes: 'MarkdownSummaryGithub;Cobertura'
+
+    - name: Publish coverage to workflow summary
+      run: cat coverage-report/SummaryGithub.md >> $env:GITHUB_STEP_SUMMARY
+
+    - name: Post coverage to PR
+      if: github.event_name == 'pull_request'
+      run: gh pr comment $env:PR_NUMBER --edit-last --create-if-none --body-file coverage-report/SummaryGithub.md
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        PR_NUMBER: ${{ github.event.number }}
+
+  publish:
+    needs: build-test
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: windows-latest
+
+    env:
+      BUILD_CONFIG: 'Release'
+      SOLUTION: 'WindowWatcher.sln'
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: Get Build Version
+      run: |
+        Import-Module .\build\GetBuildVersion.psm1
+        Write-Host $Env:GITHUB_REF
+        $version = GetBuildVersion -VersionString $Env:GITHUB_REF
+        echo "BUILD_VERSION=$version" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
+      shell: pwsh
+
+    - name: Setup .NET 8.0
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: 8.0.x
+
+    - name: Setup .NET 10.0
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: 10.0.x
+
+    - name: Restore dependencies
+      run: dotnet restore $env:SOLUTION
+
+    - name: Build
+      run: dotnet build $env:SOLUTION --configuration $env:BUILD_CONFIG --no-restore -p:Version=$env:BUILD_VERSION
+
+    - name: Pack
+      run: >
+        dotnet pack src/WindowWatcher/WindowWatcher.csproj
+        --configuration $env:BUILD_CONFIG
+        --no-build
+        -p:Version=$env:BUILD_VERSION
+        --output ./nupkg
+
+    - name: Publish to NuGet.org
+      run: >
+        dotnet nuget push ./nupkg/*.nupkg
+        --source 'https://api.nuget.org/v3/index.json'
+        --api-key ${{ secrets.NUGET_API_KEY }}
+        --skip-duplicate

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,6 +5,7 @@
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <ContinuousIntegrationBuild Condition="'$(CI)' == 'true'">true</ContinuousIntegrationBuild>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <Version>1.0.0.0</Version>
     <Authors>James Croft</Authors>
@@ -27,7 +28,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.203" PrivateAssets="All"/>
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="all" IncludeAssets="runtime; build; native; contentfiles; analyzers; buildtransitive"/>
   </ItemGroup>
 

--- a/WindowWatcher.sln
+++ b/WindowWatcher.sln
@@ -7,23 +7,64 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WindowWatcher", "src\Window
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WindowWatcher.Console", "samples\WindowWatcher.Console\WindowWatcher.Console.csproj", "{35525948-C7DD-4C95-B38E-445B59AB007F}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{0AB3BF05-4346-4AA6-1389-037BE0695223}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WindowWatcher.Tests", "tests\WindowWatcher.Tests\WindowWatcher.Tests.csproj", "{5622687B-6069-4F9E-807C-B0DB33138788}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{827E0CD3-B72D-47B6-A68D-7590B98EB39B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{0237FC40-2A9B-4C1D-ACEC-98CC06DF2C26}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{0237FC40-2A9B-4C1D-ACEC-98CC06DF2C26}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0237FC40-2A9B-4C1D-ACEC-98CC06DF2C26}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{0237FC40-2A9B-4C1D-ACEC-98CC06DF2C26}.Debug|x64.Build.0 = Debug|Any CPU
+		{0237FC40-2A9B-4C1D-ACEC-98CC06DF2C26}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{0237FC40-2A9B-4C1D-ACEC-98CC06DF2C26}.Debug|x86.Build.0 = Debug|Any CPU
 		{0237FC40-2A9B-4C1D-ACEC-98CC06DF2C26}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{0237FC40-2A9B-4C1D-ACEC-98CC06DF2C26}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0237FC40-2A9B-4C1D-ACEC-98CC06DF2C26}.Release|x64.ActiveCfg = Release|Any CPU
+		{0237FC40-2A9B-4C1D-ACEC-98CC06DF2C26}.Release|x64.Build.0 = Release|Any CPU
+		{0237FC40-2A9B-4C1D-ACEC-98CC06DF2C26}.Release|x86.ActiveCfg = Release|Any CPU
+		{0237FC40-2A9B-4C1D-ACEC-98CC06DF2C26}.Release|x86.Build.0 = Release|Any CPU
 		{35525948-C7DD-4C95-B38E-445B59AB007F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{35525948-C7DD-4C95-B38E-445B59AB007F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{35525948-C7DD-4C95-B38E-445B59AB007F}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{35525948-C7DD-4C95-B38E-445B59AB007F}.Debug|x64.Build.0 = Debug|Any CPU
+		{35525948-C7DD-4C95-B38E-445B59AB007F}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{35525948-C7DD-4C95-B38E-445B59AB007F}.Debug|x86.Build.0 = Debug|Any CPU
 		{35525948-C7DD-4C95-B38E-445B59AB007F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{35525948-C7DD-4C95-B38E-445B59AB007F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{35525948-C7DD-4C95-B38E-445B59AB007F}.Release|x64.ActiveCfg = Release|Any CPU
+		{35525948-C7DD-4C95-B38E-445B59AB007F}.Release|x64.Build.0 = Release|Any CPU
+		{35525948-C7DD-4C95-B38E-445B59AB007F}.Release|x86.ActiveCfg = Release|Any CPU
+		{35525948-C7DD-4C95-B38E-445B59AB007F}.Release|x86.Build.0 = Release|Any CPU
+		{5622687B-6069-4F9E-807C-B0DB33138788}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5622687B-6069-4F9E-807C-B0DB33138788}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5622687B-6069-4F9E-807C-B0DB33138788}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{5622687B-6069-4F9E-807C-B0DB33138788}.Debug|x64.Build.0 = Debug|Any CPU
+		{5622687B-6069-4F9E-807C-B0DB33138788}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{5622687B-6069-4F9E-807C-B0DB33138788}.Debug|x86.Build.0 = Debug|Any CPU
+		{5622687B-6069-4F9E-807C-B0DB33138788}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5622687B-6069-4F9E-807C-B0DB33138788}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5622687B-6069-4F9E-807C-B0DB33138788}.Release|x64.ActiveCfg = Release|Any CPU
+		{5622687B-6069-4F9E-807C-B0DB33138788}.Release|x64.Build.0 = Release|Any CPU
+		{5622687B-6069-4F9E-807C-B0DB33138788}.Release|x86.ActiveCfg = Release|Any CPU
+		{5622687B-6069-4F9E-807C-B0DB33138788}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{5622687B-6069-4F9E-807C-B0DB33138788} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {8CA99022-F9DF-4EB0-84B7-3E459D31FC21}

--- a/samples/WindowWatcher.Console/WindowWatcher.Console.csproj
+++ b/samples/WindowWatcher.Console/WindowWatcher.Console.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0-windows;net10.0-windows</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <RootNamespace>WindowWatcher</RootNamespace>

--- a/src/WindowWatcher/ForegroundWindowWatcher.cs
+++ b/src/WindowWatcher/ForegroundWindowWatcher.cs
@@ -87,6 +87,7 @@ public class ForegroundWindowWatcher : IForegroundWindowWatcher, IDisposable
             return;
         }
 
+        this.Stop();
         this.timer.Tick -= this.OnTimerTick;
         this.timer.Dispose();
         this.WindowChanged = null;

--- a/src/WindowWatcher/WindowHelper.cs
+++ b/src/WindowWatcher/WindowHelper.cs
@@ -1,12 +1,11 @@
 namespace WindowWatcher;
 
 using System.Runtime.InteropServices;
-using System.Text;
 
 /// <summary>
 /// Defines a helper class for interacting with the user32.dll windowing APIs.
 /// </summary>
-public static class WindowHelper
+public static partial class WindowHelper
 {
     /// <summary>
     /// Gets the current foreground (active) window.
@@ -17,17 +16,18 @@ public static class WindowHelper
         var handle = GetForegroundWindow();
 
         var bufferSize = GetWindowTextLength(handle) + 1;
-        var buffer = new StringBuilder(bufferSize);
+        var buffer = new char[bufferSize];
 
-        return GetWindowText(handle, buffer, bufferSize) > 0 ? new Window(handle, buffer.ToString()) : null;
+        var length = GetWindowText(handle, buffer, bufferSize);
+        return length > 0 ? new Window(handle, new string(buffer, 0, length)) : null;
     }
 
-    [DllImport("user32.dll")]
-    private static extern IntPtr GetForegroundWindow();
+    [LibraryImport("user32.dll")]
+    private static partial IntPtr GetForegroundWindow();
 
-    [DllImport("user32.dll")]
-    private static extern int GetWindowTextLength(IntPtr hWnd);
+    [LibraryImport("user32.dll", EntryPoint = "GetWindowTextLengthW")]
+    private static partial int GetWindowTextLength(IntPtr hWnd);
 
-    [DllImport("user32.dll")]
-    private static extern int GetWindowText(IntPtr hWnd, StringBuilder text, int count);
+    [LibraryImport("user32.dll", EntryPoint = "GetWindowTextW", StringMarshalling = StringMarshalling.Utf16)]
+    private static partial int GetWindowText(IntPtr hWnd, [Out] char[] lpString, int nMaxCount);
 }

--- a/src/WindowWatcher/WindowWatcher.csproj
+++ b/src/WindowWatcher/WindowWatcher.csproj
@@ -3,9 +3,10 @@
   <PropertyGroup>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <OutputType>Library</OutputType>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0-windows;net10.0-windows</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Product>Window Watcher</Product>
     <Description>
       Window Watcher is an SDK built on the user32.dll GetForegroundWindow API to provide a watcher for active window changes on Windows devices.

--- a/tests/WindowWatcher.Tests/ForegroundWindowWatcherIntegrationTests.cs
+++ b/tests/WindowWatcher.Tests/ForegroundWindowWatcherIntegrationTests.cs
@@ -1,0 +1,81 @@
+namespace WindowWatcher.Tests;
+
+/// <summary>
+/// Integration tests for ForegroundWindowWatcher that validate the watcher
+/// lifecycle and event infrastructure work correctly on the running architecture.
+/// </summary>
+public class ForegroundWindowWatcherIntegrationTests : IDisposable
+{
+    private readonly ForegroundWindowWatcher watcher = new();
+
+    [Fact]
+    public void Start_SetsIsRunningToTrue()
+    {
+        watcher.Start();
+
+        Assert.True(watcher.IsRunning);
+    }
+
+    [Fact]
+    public void Stop_SetsIsRunningToFalse()
+    {
+        watcher.Start();
+        watcher.Stop();
+
+        Assert.False(watcher.IsRunning);
+    }
+
+    [Fact]
+    public void Start_WithInterval_SetsIsRunningToTrue()
+    {
+        watcher.Start(TimeSpan.FromSeconds(1));
+
+        Assert.True(watcher.IsRunning);
+    }
+
+    [Fact]
+    public void Start_WithIntervalMs_SetsIsRunningToTrue()
+    {
+        watcher.Start(1000);
+
+        Assert.True(watcher.IsRunning);
+    }
+
+    [Fact]
+    public void Dispose_StopsWatcher()
+    {
+        watcher.Start();
+        watcher.Dispose();
+
+        Assert.False(watcher.IsRunning);
+    }
+
+    [Fact]
+    public async Task Start_RaisesWindowChangedEvent_WhenForegroundWindowExists()
+    {
+        var eventRaised = new TaskCompletionSource<WindowChangedEventArgs>();
+
+        watcher.WindowChanged += (_, args) =>
+        {
+            eventRaised.TrySetResult(args);
+        };
+
+        watcher.Start(TimeSpan.FromMilliseconds(100));
+
+        // In CI or headless environments, the event may not fire if there is
+        // no titled foreground window. Use a timeout to avoid hanging.
+        var completed = await Task.WhenAny(eventRaised.Task, Task.Delay(3000));
+
+        if (completed == eventRaised.Task)
+        {
+            var args = await eventRaised.Task;
+            Assert.NotNull(args.NewWindow);
+            Assert.NotEqual(IntPtr.Zero, args.NewWindow!.Handle);
+        }
+    }
+
+    public void Dispose()
+    {
+        watcher.Dispose();
+    }
+}

--- a/tests/WindowWatcher.Tests/WindowChangedEventArgsTests.cs
+++ b/tests/WindowWatcher.Tests/WindowChangedEventArgsTests.cs
@@ -1,0 +1,21 @@
+namespace WindowWatcher.Tests;
+
+public class WindowChangedEventArgsTests
+{
+    [Fact]
+    public void Constructor_SetsNewWindow()
+    {
+        var window = new Window(new IntPtr(1), "Test");
+        var args = new WindowChangedEventArgs(window);
+
+        Assert.Equal(window, args.NewWindow);
+    }
+
+    [Fact]
+    public void Constructor_WithNull_SetsNullNewWindow()
+    {
+        var args = new WindowChangedEventArgs(null);
+
+        Assert.Null(args.NewWindow);
+    }
+}

--- a/tests/WindowWatcher.Tests/WindowHelperIntegrationTests.cs
+++ b/tests/WindowWatcher.Tests/WindowHelperIntegrationTests.cs
@@ -1,0 +1,30 @@
+namespace WindowWatcher.Tests;
+
+/// <summary>
+/// Integration tests for WindowHelper that validate P/Invoke calls
+/// work correctly on the running architecture (x64, ARM64).
+/// </summary>
+public class WindowHelperIntegrationTests
+{
+    [Fact]
+    public void GetCurrentForegroundWindow_DoesNotThrow()
+    {
+        var exception = Record.Exception(() => WindowHelper.GetCurrentForegroundWindow());
+
+        Assert.Null(exception);
+    }
+
+    [Fact]
+    public void GetCurrentForegroundWindow_WhenWindowExists_ReturnsWindowWithNonZeroHandle()
+    {
+        var window = WindowHelper.GetCurrentForegroundWindow();
+
+        // In CI or headless environments, there may not be a titled foreground window.
+        // If a window is returned, validate it has a valid handle and title.
+        if (window is not null)
+        {
+            Assert.NotEqual(IntPtr.Zero, window.Handle);
+            Assert.False(string.IsNullOrEmpty(window.Title));
+        }
+    }
+}

--- a/tests/WindowWatcher.Tests/WindowTests.cs
+++ b/tests/WindowWatcher.Tests/WindowTests.cs
@@ -1,0 +1,119 @@
+namespace WindowWatcher.Tests;
+
+public class WindowTests
+{
+    [Fact]
+    public void Empty_HasZeroHandleAndEmptyTitle()
+    {
+        var window = Window.Empty;
+
+        Assert.Equal(IntPtr.Zero, window.Handle);
+        Assert.Equal(string.Empty, window.Title);
+    }
+
+    [Fact]
+    public void Constructor_SetsProperties()
+    {
+        var handle = new IntPtr(12345);
+        var title = "Test Window";
+
+        var window = new Window(handle, title);
+
+        Assert.Equal(handle, window.Handle);
+        Assert.Equal(title, window.Title);
+    }
+
+    [Fact]
+    public void Equals_SameHandleAndTitle_ReturnsTrue()
+    {
+        var window1 = new Window(new IntPtr(1), "Title");
+        var window2 = new Window(new IntPtr(1), "Title");
+
+        Assert.True(window1.Equals(window2));
+    }
+
+    [Fact]
+    public void Equals_DifferentHandle_ReturnsFalse()
+    {
+        var window1 = new Window(new IntPtr(1), "Title");
+        var window2 = new Window(new IntPtr(2), "Title");
+
+        Assert.False(window1.Equals(window2));
+    }
+
+    [Fact]
+    public void Equals_DifferentTitle_ReturnsFalse()
+    {
+        var window1 = new Window(new IntPtr(1), "Title A");
+        var window2 = new Window(new IntPtr(1), "Title B");
+
+        Assert.False(window1.Equals(window2));
+    }
+
+    [Fact]
+    public void Equals_NullWindow_ReturnsFalse()
+    {
+        var window = new Window(new IntPtr(1), "Title");
+
+        Assert.False(window.Equals((Window?)null));
+    }
+
+    [Fact]
+    public void Equals_SameReference_ReturnsTrue()
+    {
+        var window = new Window(new IntPtr(1), "Title");
+
+        Assert.True(window.Equals(window));
+    }
+
+    [Fact]
+    public void Equals_Object_SameValues_ReturnsTrue()
+    {
+        var window1 = new Window(new IntPtr(1), "Title");
+        object window2 = new Window(new IntPtr(1), "Title");
+
+        Assert.True(window1.Equals(window2));
+    }
+
+    [Fact]
+    public void Equals_Object_DifferentType_ReturnsFalse()
+    {
+        var window = new Window(new IntPtr(1), "Title");
+
+        Assert.False(window.Equals("not a window"));
+    }
+
+    [Fact]
+    public void Equals_Object_Null_ReturnsFalse()
+    {
+        var window = new Window(new IntPtr(1), "Title");
+
+        Assert.False(window.Equals((object?)null));
+    }
+
+    [Fact]
+    public void Equals_Object_SameReference_ReturnsTrue()
+    {
+        var window = new Window(new IntPtr(1), "Title");
+
+        Assert.True(window.Equals((object)window));
+    }
+
+    [Fact]
+    public void GetHashCode_EqualWindows_ReturnsSameHashCode()
+    {
+        var window1 = new Window(new IntPtr(1), "Title");
+        var window2 = new Window(new IntPtr(1), "Title");
+
+        Assert.Equal(window1.GetHashCode(), window2.GetHashCode());
+    }
+
+    [Fact]
+    public void GetHashCode_DifferentWindows_ReturnsDifferentHashCode()
+    {
+        var window1 = new Window(new IntPtr(1), "Title A");
+        var window2 = new Window(new IntPtr(2), "Title B");
+
+        Assert.NotEqual(window1.GetHashCode(), window2.GetHashCode());
+    }
+}

--- a/tests/WindowWatcher.Tests/WindowWatcher.Tests.csproj
+++ b/tests/WindowWatcher.Tests/WindowWatcher.Tests.csproj
@@ -1,0 +1,25 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net8.0-windows;net10.0-windows</TargetFrameworks>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\WindowWatcher\WindowWatcher.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Drop net6.0 and net7.0 (EOL), target net8.0-windows and net10.0-windows. Replace DllImport with source-generated LibraryImport for AOT and cross-architecture compatibility.

Add integration tests validated on x64 and ARM64 via CI matrix, with code coverage reporting to workflow summaries and PR comments.

Modernize CI to use dotnet build, actions/checkout v4, actions/setup-dotnet v4, and explicit dotnet pack with --skip-duplicate for idempotent publishing.

Fix ForegroundWindowWatcher.Dispose not calling Stop().

Closes #8