### PR TITLE
fix(ci): resolve PowerShell glob for NuGet push on Windows runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,8 +144,7 @@ jobs:
         --output ./nupkg
 
     - name: Publish to NuGet.org
-      run: >
-        dotnet nuget push ./nupkg/*.nupkg
-        --source 'https://api.nuget.org/v3/index.json'
-        --api-key ${{ secrets.NUGET_API_KEY }}
-        --skip-duplicate
+      run: |
+        Get-ChildItem ./nupkg -Filter *.nupkg | ForEach-Object {
+          dotnet nuget push $_.FullName --source 'https://api.nuget.org/v3/index.json' --api-key '${{ secrets.NUGET_API_KEY }}' --skip-duplicate
+        }


### PR DESCRIPTION
PowerShell does not expand wildcard globs in command arguments. Use Get-ChildItem to enumerate .nupkg files and push each one explicitly.