### PR TITLE
chore: improve dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,13 +12,13 @@ updates:
   groups:
     testing:
       patterns:
-      - "coverlet*"
-      - "Microsoft.NET.Test*"
-      - "xunit*"
+        - "coverlet*"
+        - "Microsoft.NET.Test*"
+        - "xunit*"
     analyzers:
       patterns:
-      - "StyleCop*"
-      - "Microsoft.SourceLink*"
+        - "StyleCop*"
+        - "Microsoft.SourceLink*"
 
 - package-ecosystem: github-actions
   directory: "/"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,5 +3,29 @@ updates:
 - package-ecosystem: nuget
   directory: "/"
   schedule:
-    interval: daily
+    interval: weekly
+    day: monday
   open-pull-requests-limit: 10
+  commit-message:
+    prefix: "chore"
+    include: "scope"
+  groups:
+    testing:
+      patterns:
+      - "coverlet*"
+      - "Microsoft.NET.Test*"
+      - "xunit*"
+    analyzers:
+      patterns:
+      - "StyleCop*"
+      - "Microsoft.SourceLink*"
+
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: weekly
+    day: monday
+  open-pull-requests-limit: 5
+  commit-message:
+    prefix: "ci"
+    include: "scope"


### PR DESCRIPTION
Add github-actions ecosystem for action version updates. Switch NuGet schedule from daily to weekly on Monday. Add commit-message prefixes for conventional commits. Group test and analyzer packages to reduce PR noise.